### PR TITLE
Allow macro expansion

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -88,8 +88,8 @@ struct Args {
 	#[clap(short, long, default_value = "README.j2")]
 	template: PathBuf,
 
-	/// Whether if we must expand the macros before generating the readme file.
-	/// This uses cargo internally and requires the nightly toolchain.
+	/// Use nightly rustc to expand macros prior to reading the source. This is necessary if you
+	/// use function-like macros in doc attributes, as introduced in Rust 1.54.
 	#[clap(long)]
 	expand_macros: bool
 }


### PR DESCRIPTION
This feature can be activated by passing `--expand-macros` flagto
the `cargo doc2readme` invocation.

In order to get the expanded version of the crate, we need to run Cargo.
The problem is that the main function already sets up a cargo instance
and that we can't run two instances of it at the same time (a lockfile
is used by Cargo in order to prevent this).

In order to allow to run Cargo, some small changes were necessary. More
precisely, we need to get the crate code before running any cargo
instance, but we can't perform any analysis on it since cargo is not
running. As such, a new step has been added in the main function, where
we just *extract* the crate code and store it in a temporary data
structure. This data structure is then passed to `input::read_file`,
which has been renamed to `input::read_code` in order to better express
the fact that files don't exist at this point.

There's a small subtility: the expanded code generated by rustc has a
prelude import manually added at the beginning of the crate. The
problem is that we're emitting a warning for every glob import,
including this prelude call. In order to fix this issue, a filter has
been added before signaling that we have met glob import, in order
to not report the prelude import as a glob import.

Here's what happens if i add the following macro in `cargo-doc2readme`
documentation:
```rust
#![doc = concat!("The crate version is *", env!("CARGO_PKG_VERSION"), "*.")]
```
![A screenshot of the top of the readme file. It is identical to the one that can be seen in the repository except that it has an additional line saying "The crate version is *0.0.7*".](https://user-images.githubusercontent.com/25402018/143312597-31412070-dd01-4923-8c06-f9459af2f437.png)

(this change has not been committed, it's just a test i made to prove 
that it works).

Fix #37 