### PR TITLE
if given "-" as the output file name, then use stdout.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -257,7 +257,12 @@ fn main() -> ExitCode {
 		}
 	} else {
 		cargo_cfg.shell().status("Writing", out.display()).ok();
-		let mut out = File::create(&out).expect("Unable to create output file");
+		let outfilename = out.file_name().expect("Unable to get output file name");
+		let mut out: Box<dyn std::io::Write> = if outfilename.to_string_lossy() == "-" {
+			Box::new(std::io::BufWriter::new(std::io::stdout()))
+		} else {
+			Box::new(std::io::BufWriter::new(File::create(&out).expect("Unable to create output file")))
+		};
 		output::emit(input_file, &template, &mut out).expect("Unable to write output file");
 		ExitCode::SUCCESS
 	};

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,7 +259,8 @@ fn main() -> ExitCode {
 		cargo_cfg.shell().status("Writing", out.display()).ok();
 		let outfilename = out.file_name().expect("Unable to get output file name");
 		if outfilename.to_string_lossy() == "-" {
-			output::emit(input_file, &template, &mut io::stdout()).expect("Unable to write to stdout!");
+			output::emit(input_file, &template, &mut io::stdout())
+				.expect("Unable to write to stdout!");
 		} else {
 			let mut file = File::create(&out).expect("Unable to create output file");
 			output::emit(input_file, &template, &mut file).expect("Unable to write output file");

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,9 +259,9 @@ fn main() -> ExitCode {
 		cargo_cfg.shell().status("Writing", out.display()).ok();
 		let outfilename = out.file_name().expect("Unable to get output file name");
 		let mut out: Box<dyn std::io::Write> = if outfilename.to_string_lossy() == "-" {
-			Box::new(std::io::BufWriter::new(std::io::stdout()))
+			Box::new(std::io::stdout())
 		} else {
-			Box::new(std::io::BufWriter::new(File::create(&out).expect("Unable to create output file")))
+			Box::new(File::create(&out).expect("Unable to create output file"))
 		};
 		output::emit(input_file, &template, &mut out).expect("Unable to write output file");
 		ExitCode::SUCCESS

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,12 +258,12 @@ fn main() -> ExitCode {
 	} else {
 		cargo_cfg.shell().status("Writing", out.display()).ok();
 		let outfilename = out.file_name().expect("Unable to get output file name");
-		let mut out: Box<dyn std::io::Write> = if outfilename.to_string_lossy() == "-" {
-			Box::new(std::io::stdout())
+		if outfilename.to_string_lossy() == "-" {
+			output::emit(input_file, &template, &mut io::stdout()).expect("Unable to write to stdout!");
 		} else {
-			Box::new(File::create(&out).expect("Unable to create output file"))
+			let mut file = File::create(&out).expect("Unable to create output file");
+			output::emit(input_file, &template, &mut file).expect("Unable to write output file");
 		};
-		output::emit(input_file, &template, &mut out).expect("Unable to write output file");
 		ExitCode::SUCCESS
 	};
 


### PR DESCRIPTION
I think addresses #117 

I think we have to box the writer, but we can still pass it to `output::emit`.
