### PR TITLE
Ensure nested lists don't alter the outer lists's appearance

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -247,7 +247,11 @@ impl<'a> Readme<'a> {
 						newline(out, &indent, &mut has_newline)?;
 						newline(out, &indent, &mut has_newline)
 					},
-					Tag::List(_) => Ok(()),
+					Tag::List(_) => {
+						let pop = lists.pop_back();
+						debug_assert!(pop.is_some());
+						Ok(())
+					},
 					Tag::Item => {
 						indent.pop_back();
 						newline(out, &indent, &mut has_newline)


### PR DESCRIPTION
Make enumerated lists count upward for improved readability of markdown sourcen source

Also remove the `lists` vector's elements when no longer used (end of list).
This saves memory when multiple lists occur.

See issue #51.

Doesn't fix the issue with nested lists.