### PR TITLE
Fix optional deps skipped by cargo metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! ADHERE TO SEMVER. DON'T EVEN USE AT YOUR OWN RISK. DON'T USE IT
 //! AT ALL.**
 
-use cargo_metadata::{MetadataCommand, Target};
+use cargo_metadata::{CargoOpt, MetadataCommand, Target};
 use log::{debug, info};
 use std::{borrow::Cow, env, fs::File, io::Read as _, path::PathBuf};
 
@@ -47,6 +47,7 @@ pub fn read_input(
 
 	// parse the cargo metadata
 	let mut cmd = MetadataCommand::new();
+	cmd.features(CargoOpt::AllFeatures);
 	if let Some(path) = &manifest_path {
 		cmd.manifest_path(path);
 	}

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,6 @@ struct CmdLine {
 macro_rules! exit_on_err {
 	($diagnostics:ident) => {
 		if $diagnostics.is_fail() {
-			$diagnostics.print().expect("Failed to print error message");
 			return ExitCode::FAILURE;
 		}
 	};
@@ -143,6 +142,7 @@ fn main() -> ExitCode {
 		args.expand_macros,
 		args.template
 	);
+	diagnostics.print().unwrap();
 	exit_on_err!(diagnostics);
 
 	let out_is_stdout = args.out.to_str() == Some("-");


### PR DESCRIPTION
Currently, optional dependencies are included in the metadata response, but their packages don't get resolved so we don't get their version. Enabling all features for `cargo metadata` solves this problem, and is also unproblematic as it doesn't compile source code so cannot trigger any *exclusive features* error messages.