### PR TITLE
default template does not show link, if doc ends with html

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This will use the latest stable Rust version available when the latest release o
 This project adheres to semantic versioning. All versions will be tested against the latest stable rust version at the time of the release. All non-bugfix changes to the rustdoc input processing and markdown output or the default readme template are considered breaking changes, as well as any non-backwards-compatible changes to the command-line arguments or to these stability guarantees. All other changes, including any changes to the Rust code, or bumping the MSRV, are not considered breaking changes.
 
 
+
  [__link0]: https://github.com
  [__link1]: https://crates.io
  [__link2]: https://rustup.rs/

--- a/src/README.j2
+++ b/src/README.j2
@@ -20,6 +20,6 @@
 
 {{ readme }}
 
-{%- if links != "" %}
+{% if links != "" %}
 {{ links }}
 {%- endif -%}

--- a/src/README.j2
+++ b/src/README.j2
@@ -20,6 +20,7 @@
 
 {{ readme }}
 
-{% if links != "" %}
+{%- if links != "" %}
+
 {{ links }}
 {%- endif -%}


### PR DESCRIPTION
The default template does not show links, if rust docs ends with html code.

This happen because there is now newline between doc and links, which cause some markdown renders like GitHub, to not interpret markdown.

Example generated `README.md`:
```md
...
<div align="center">
		<img src="https://github.com/LuckyTurtleDev/mission2teegarden-b/assets/44570204/68403ebd-ce64-4baa-bba2-b52962b89d5c" width=80%>
 </div>
 [__cargo_doc2readme_dependencies_info]: ggGkYW0BYXSEGxZ8633wCs_9GzKKlc-jeF26G4eLyZuq8IdiG7yPhHI4iD8_YXKEGxvALrpccUwnG3LtwJOv_IT2G96ptTVep6W9G7qKrdEKLREhYWSBgndtaXNzaW9uMnRlZWdhcmRlbl9iX21hcGUwLjEuMA
...
```