### PR TITLE
Bump pulldown-cmark to 0.11 and pulldown-cmark-to-cmark to 15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
+checksum = "8746739f11d39ce5ad5c2520a9b75285310dbfe78c541ccf832d38615765aec0"
 dependencies = [
  "bitflags",
  "memchr",
@@ -502,15 +502,15 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-escape"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "13.0.0"
+version = "15.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f609795c8d835f79dcfcf768415b9fb57ef1b74891e99f86e73f43a7a257163b"
+checksum = "b9c77db841443d89a57ae94f22d29c022f6d9f41b00bddbf1f4024dbaf4bdce1"
 dependencies = [
  "pulldown-cmark",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ memchr = "2.7"
 minijinja = { version = "2.0", features = ["builtins", "debug", "key_interning", "urlencode"], default-features = false }
 monostate = "0.1"
 proc-macro2 = { version = "1.0", features = ["span-locations"], default-features = false }
-pulldown-cmark = { version = "0.10", default-features = false }
-pulldown-cmark-to-cmark = "13.0"
+pulldown-cmark = { version = "0.11", default-features = false }
+pulldown-cmark-to-cmark = "15.0"
 quote = "1.0"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -43,7 +43,7 @@ syn = { version = "2.0", features = ["clone-impls", "full", "parsing", "printing
 url = "2.5"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-pulldown-cmark = { version = "0.10", default-features = false, features = ["simd"] }
+pulldown-cmark = { version = "0.11", default-features = false, features = ["simd"] }
 
 [dev-dependencies]
 hex = "0.4.3"


### PR DESCRIPTION
This PR partially reverts #434 since support for GitHub Alerts has been built into pulldown-cmark 0.11. The test cases from #434 remain to ensure nothing breaks :)